### PR TITLE
fix: add re-entrancy guard to prevent duplicate spans in connection wrapper chains

### DIFF
--- a/src/DoctrineInstrumentation.php
+++ b/src/DoctrineInstrumentation.php
@@ -20,6 +20,14 @@ class DoctrineInstrumentation
 {
     public const NAME = 'doctrine';
 
+    /**
+     * Re-entrancy guard: Doctrine's connection wrapper chain fires hooks at
+     * every layer. Only the outermost call creates and ends a span.
+     *
+     * @var array<string, int>
+     */
+    private static array $depth = [];
+
     public static function register(): void
     {
         $instrumentation = new CachedInstrumentation('io.opentelemetry.contrib.php.doctrine');
@@ -29,6 +37,10 @@ class DoctrineInstrumentation
             \Doctrine\DBAL\Driver::class,
             'connect',
             pre: static function (\Doctrine\DBAL\Driver $driver, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation) {
+                self::$depth['connect'] = (self::$depth['connect'] ?? 0) + 1;
+                if (self::$depth['connect'] > 1) {
+                    return null;
+                }
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = self::makeBuilder($instrumentation, 'Doctrine\DBAL\Driver::connect', $function, $class, $filename, $lineno)
                     ->setSpanKind(SpanKind::KIND_CLIENT)
@@ -41,7 +53,10 @@ class DoctrineInstrumentation
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\Doctrine\DBAL\Driver $driver, array $params, ?\Doctrine\DBAL\Driver\Connection $connection, ?Throwable $exception) {
-                self::end($exception);
+                self::$depth['connect'] = max(0, (self::$depth['connect'] ?? 1) - 1);
+                if (self::$depth['connect'] === 0) {
+                    self::end($exception);
+                }
             }
         );
 
@@ -49,6 +64,10 @@ class DoctrineInstrumentation
             \Doctrine\DBAL\Driver\Connection::class,
             'query',
             pre: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation) {
+                self::$depth['query'] = (self::$depth['query'] ?? 0) + 1;
+                if (self::$depth['query'] > 1) {
+                    return null;
+                }
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = self::makeBuilder($instrumentation, AttributesResolver::getDbQuerySummary($params), $function, $class, $filename, $lineno)
                     ->setSpanKind(SpanKind::KIND_CLIENT);
@@ -60,7 +79,10 @@ class DoctrineInstrumentation
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, mixed $statement, ?Throwable $exception) {
-                self::end($exception);
+                self::$depth['query'] = max(0, (self::$depth['query'] ?? 1) - 1);
+                if (self::$depth['query'] === 0) {
+                    self::end($exception);
+                }
             }
         );
 
@@ -68,6 +90,10 @@ class DoctrineInstrumentation
             \Doctrine\DBAL\Driver\Connection::class,
             'exec',
             pre: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation) {
+                self::$depth['exec'] = (self::$depth['exec'] ?? 0) + 1;
+                if (self::$depth['exec'] > 1) {
+                    return null;
+                }
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = self::makeBuilder($instrumentation, AttributesResolver::getDbQuerySummary($params), $function, $class, $filename, $lineno)
                     ->setSpanKind(SpanKind::KIND_CLIENT)
@@ -80,7 +106,10 @@ class DoctrineInstrumentation
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, mixed $statement, ?Throwable $exception) {
-                self::end($exception);
+                self::$depth['exec'] = max(0, (self::$depth['exec'] ?? 1) - 1);
+                if (self::$depth['exec'] === 0) {
+                    self::end($exception);
+                }
             }
         );
 
@@ -88,6 +117,10 @@ class DoctrineInstrumentation
             \Doctrine\DBAL\Driver\Connection::class,
             'prepare',
             pre: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation) {
+                self::$depth['prepare'] = (self::$depth['prepare'] ?? 0) + 1;
+                if (self::$depth['prepare'] > 1) {
+                    return null;
+                }
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = self::makeBuilder($instrumentation, AttributesResolver::getDbQuerySummary($params), $function, $class, $filename, $lineno)
                     ->setSpanKind(SpanKind::KIND_CLIENT)
@@ -107,7 +140,10 @@ class DoctrineInstrumentation
                         $tracker->trackStatement($statement, $span->getContext());
                     }
                 }
-                self::end($exception);
+                self::$depth['prepare'] = max(0, (self::$depth['prepare'] ?? 1) - 1);
+                if (self::$depth['prepare'] === 0) {
+                    self::end($exception);
+                }
             }
         );
 
@@ -115,6 +151,10 @@ class DoctrineInstrumentation
             \Doctrine\DBAL\Driver\Connection::class,
             'beginTransaction',
             pre: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation) {
+                self::$depth['beginTransaction'] = (self::$depth['beginTransaction'] ?? 0) + 1;
+                if (self::$depth['beginTransaction'] > 1) {
+                    return null;
+                }
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = self::makeBuilder($instrumentation, 'Doctrine::beginTransaction', $function, $class, $filename, $lineno)
                     ->setSpanKind(SpanKind::KIND_CLIENT)
@@ -125,7 +165,10 @@ class DoctrineInstrumentation
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, mixed $statement, ?Throwable $exception) {
-                self::end($exception);
+                self::$depth['beginTransaction'] = max(0, (self::$depth['beginTransaction'] ?? 1) - 1);
+                if (self::$depth['beginTransaction'] === 0) {
+                    self::end($exception);
+                }
             }
         );
 
@@ -133,6 +176,10 @@ class DoctrineInstrumentation
             \Doctrine\DBAL\Driver\Connection::class,
             'commit',
             pre: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation) {
+                self::$depth['commit'] = (self::$depth['commit'] ?? 0) + 1;
+                if (self::$depth['commit'] > 1) {
+                    return null;
+                }
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = self::makeBuilder($instrumentation, 'Doctrine::commit', $function, $class, $filename, $lineno)
                     ->setSpanKind(SpanKind::KIND_CLIENT)
@@ -143,7 +190,10 @@ class DoctrineInstrumentation
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, mixed $statement, ?Throwable $exception) {
-                self::end($exception);
+                self::$depth['commit'] = max(0, (self::$depth['commit'] ?? 1) - 1);
+                if (self::$depth['commit'] === 0) {
+                    self::end($exception);
+                }
             }
         );
 
@@ -151,6 +201,10 @@ class DoctrineInstrumentation
             \Doctrine\DBAL\Driver\Connection::class,
             'rollBack',
             pre: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation) {
+                self::$depth['rollBack'] = (self::$depth['rollBack'] ?? 0) + 1;
+                if (self::$depth['rollBack'] > 1) {
+                    return null;
+                }
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = self::makeBuilder($instrumentation, 'Doctrine::rollBack', $function, $class, $filename, $lineno)
                     ->setSpanKind(SpanKind::KIND_CLIENT)
@@ -160,7 +214,10 @@ class DoctrineInstrumentation
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\Doctrine\DBAL\Driver\Connection $connection, array $params, mixed $statement, ?Throwable $exception) {
-                self::end($exception);
+                self::$depth['rollBack'] = max(0, (self::$depth['rollBack'] ?? 1) - 1);
+                if (self::$depth['rollBack'] === 0) {
+                    self::end($exception);
+                }
             }
         );
 
@@ -168,6 +225,10 @@ class DoctrineInstrumentation
             \Doctrine\DBAL\Driver\Statement::class,
             'execute',
             pre: static function (\Doctrine\DBAL\Driver\Statement $statement, array $params, string $class, string $function, ?string $filename, ?int $lineno) use ($instrumentation, $tracker) {
+                self::$depth['execute'] = (self::$depth['execute'] ?? 0) + 1;
+                if (self::$depth['execute'] > 1) {
+                    return null;
+                }
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $builder = self::makeBuilder($instrumentation, 'Doctrine::execute', $function, $class, $filename, $lineno)
                     ->setSpanKind(SpanKind::KIND_CLIENT)
@@ -181,7 +242,10 @@ class DoctrineInstrumentation
                 Context::storage()->attach($span->storeInContext($parent));
             },
             post: static function (\Doctrine\DBAL\Driver\Statement $statement, array $params, ?ResultInterface $result, ?Throwable $exception) {
-                self::end($exception);
+                self::$depth['execute'] = max(0, (self::$depth['execute'] ?? 1) - 1);
+                if (self::$depth['execute'] === 0) {
+                    self::end($exception);
+                }
             }
         );
     }


### PR DESCRIPTION
## Problem

When Doctrine is configured with a connection wrapper chain (e.g. custom middleware or any `Driver` that delegates to an inner `Driver`), the PHP OTel hooks fire at every layer. This produces N duplicate spans per operation where N equals the number of wrapper layers, making traces noisy and misleading.

Tracked in: open-telemetry/opentelemetry-php#1931

## Fix

Add a static `$depth` counter per hooked method. The pre-hook increments the counter and skips span creation if `depth > 1`. The post-hook decrements the counter and only calls `end()` at depth 0.

```php
private static array $depth = [];

// pre-hook:
self::$depth['connect'] = (self::$depth['connect'] ?? 0) + 1;
if (self::$depth['connect'] > 1) {
    return null;
}

// post-hook:
self::$depth['connect'] = max(0, (self::$depth['connect'] ?? 1) - 1);
if (self::$depth['connect'] === 0) {
    self::end($exception);
}
```

This ensures only the outermost invocation creates and ends a span, regardless of how many wrapper layers are in the chain. All 8 hooked methods are covered: `connect`, `query`, `exec`, `prepare`, `beginTransaction`, `commit`, `rollBack`, `execute`.

## Testing

The fix is already confirmed working in our staging environment via a backported patch on `0.3.1`, where it resolved duplicate Doctrine spans caused by our connection wrapper setup.